### PR TITLE
Add send command to cli

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -49,7 +49,7 @@
   revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
 
 [[projects]]
-  digest = "1:28e3810b11adeeee4c28e9d539552806931872619aff0c4644b9c87cc0b7afd9"
+  digest = "1:bdda1984e8f7e4c2ec7fcc57bb5a4045cfdddba71ea07a768c726b026f42f9fe"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -76,6 +76,8 @@
     "x/auth/client/cli",
     "x/auth/client/txbuilder",
     "x/bank",
+    "x/bank/client",
+    "x/bank/client/cli",
     "x/distribution",
     "x/distribution/keeper",
     "x/distribution/tags",
@@ -222,12 +224,13 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
+  digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
     "hcl/ast",
     "hcl/parser",
+    "hcl/printer",
     "hcl/scanner",
     "hcl/strconv",
     "hcl/token",
@@ -441,7 +444,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:59483b8e8183f10ab21a85ba1f4cbb4a2335d48891801f79ed7b9499f44d383c"
+  digest = "1:9ff9e1808adfc43f788f1c1e9fd2660c285b522243da985a4c043ec6f2a2d736"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -458,7 +461,7 @@
     "leveldb/util",
   ]
   pruneopts = "UT"
-  revision = "6b91fda63f2e36186f1c9d0e48578defb69c5d43"
+  revision = "f9080354173f192dfc8821931eacf9cfd6819253"
 
 [[projects]]
   digest = "1:605b6546f3f43745695298ec2d342d3e952b6d91cdf9f349bea9315f677d759f"
@@ -574,7 +577,6 @@
   version = "v0.1.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:aaff04fa01d9b824fde6799759cc597b3ac3671b9ad31924c28b6557d0ee5284"
   name = "golang.org/x/crypto"
   packages = [
@@ -616,14 +618,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3f6e1af4cc2c512f2001d5870dc317ab93e68baf0f005d558d4c957c125602d9"
+  digest = "1:e9609f7e36a3fecb7dc9e3a15f9881011f9d8c42f94c9d5da231eb0c07826dc8"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "UT"
-  revision = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89"
+  revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -654,7 +656,7 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "b69ba1387ce2108ac9bc8e8e5e5a46e7d5c72313"
+  revision = "5fc9ac5403620be16bcdb0c8e7644b1178472c3b"
 
 [[projects]]
   digest = "1:2dab32a43451e320e49608ff4542fdfc653c95dcc35d0065ec9c6c3dd540ed74"
@@ -717,6 +719,7 @@
     "github.com/cosmos/cosmos-sdk/x/auth/client/cli",
     "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder",
     "github.com/cosmos/cosmos-sdk/x/bank",
+    "github.com/cosmos/cosmos-sdk/x/bank/client/cli",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/tendermint/tendermint/abci/types",

--- a/README.md
+++ b/README.md
@@ -93,11 +93,17 @@ To initialize configuration and a `genesis.json` file for your application and a
 > _*NOTE*_: Copy the `chain-id` from the output of the first command, and `Address` from the output of the second and save it for use when running the application commands a bit further down
 
 ```bash
-# Copy the chain_id output here and save it for later user
+# Copy the chain_id and app_message.secret output here and save it for later user
 nameserviced init
 
+# Use app_message.secret recover jack's account. 
 # Copy the `Address` output here and save it for later use
-nameservicecli keys add jack
+nameservicecli keys add jack --recover
+
+# Create another account with random secret.
+# Copy the `Address` output here and save it for later use
+nameservicecli keys add tim
+
 ```
 
 Next open the generated file `~/.nameserviced/config/genesis.json` in a text editor and copy the address output from the `nameservicecli keys add` command in the `"address"` field under `"accounts"`. This will give you control over a wallet with some coins when you start your local network.
@@ -109,14 +115,21 @@ Open another terminal to run commands against the network you have just created:
 > _*NOTE*_: In the below commands `--chain-id` and `accountaddr` are pulled using terminal utilities. You can also just input the raw strings saved from bootstrapping the network above. The commands require [`jq`](https://stedolan.github.io/jq/download/) to be installed on your machine.
 
 ```bash
-# First check the account to ensure you have funds
-nameservicecli query account $(nameservicecli keys list -o json | jq -r .[0].address) --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
+# First check the accounts to ensure they have funds
+nameservicecli query account $(nameservicecli keys list -o json | jq -r .[0].address) \
+    --indent --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id) 
+nameservicecli query account $(nameservicecli keys list -o json | jq -r .[1].address) \
+    --indent --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id) 
 
 # Buy your first name using your coins from the genesis file
-nameservicecli tx  buy-name jack.id 5mycoin --from $(nameservicecli keys list -o json | jq -r .[0].address) --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
+nameservicecli tx buy-name jack.id 5mycoin \
+    --from     $(nameservicecli keys list -o json | jq -r .[0].address) \
+    --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
 
 # Set the value for the name you just bought
-nameservicecli tx set-name jack.id 8.8.8.8 --from $(nameservicecli keys list -o json | jq -r .[0].address) --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
+nameservicecli tx set-name jack.id 8.8.8.8 \
+    --from     $(nameservicecli keys list -o json | jq -r .[0].address) \
+    --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
 
 # Try out a resolve query against the name you registered
 nameservicecli query resolve jack.id --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
@@ -125,4 +138,18 @@ nameservicecli query resolve jack.id --chain-id $(cat ~/.nameserviced/config/gen
 # Try out a whois query against the name you just registered
 nameservicecli query whois jack.id --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
 # > {"value":"8.8.8.8","owner":"cosmos1l7k5tdt2qam0zecxrx78yuw447ga54dsmtpk2s","price":[{"denom":"mycoin","amount":"5"}]}
+
+# Jack send some coin to tim, then tim can buy name from jack.  
+nameservicecli tx send \
+    --from     $(nameservicecli keys list -o json | jq -r .[0].address) \
+    --to       $(nameservicecli keys list -o json | jq -r .[1].address) \
+    --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id) \
+    --amount 1000mycoin
+
+# Tim buy name from jack
+nameservicecli tx buy-name jack.id 10mycoin \
+    --from     $(nameservicecli keys list -o json | jq -r .[0].address) \
+    --chain-id $(cat ~/.nameserviced/config/genesis.json | jq -r .chain_id)
+
+
 ```

--- a/cmd/nameservicecli/main.go
+++ b/cmd/nameservicecli/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tendermint/tendermint/libs/cli"
 
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
 	app "github.com/cosmos/sdk-application-tutorial"
 	nameservicecmd "github.com/cosmos/sdk-application-tutorial/x/nameservice/client/cli"
 )
@@ -56,6 +57,7 @@ func main() {
 	}
 
 	txCmd.AddCommand(client.PostCommands(
+		bankcmd.SendTxCmd(cdc),
 		nameservicecmd.GetCmdBuyName(cdc),
 		nameservicecmd.GetCmdSetName(cdc),
 	)...)


### PR DESCRIPTION
After adding command `nameservicecli tx send`, users can operate with multiple roles.
Add specification for buying name from another, and format bash shell.