### PR TITLE
In tutorial, instruct to run `dep ensure` first

### DIFF
--- a/tutorial/dep.md
+++ b/tutorial/dep.md
@@ -107,7 +107,7 @@ Now that this bit of house keeping is done, its time to install dep, as well as 
 
 ```bash
 make get_tools
-dep init -v
+dep ensure -v
 ```
 
 ## Building the app


### PR DESCRIPTION
In the tutorial, instruct the user to run `dep ensure -v` in order to bootstrap the dependency configuration as `dep init` will simply bail due to the fact that Gopkg.toml already exists.