### PR TITLE
Implement version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 DEP := $(shell command -v dep 2> /dev/null)
+# TODO: Uncomment once tagged versions exist
+# VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
+VERSION := 0.0.1
+COMMIT := $(shell git log -1 --format='%H')
+
+ldflags = -X github.com/cosmos/sdk-application-tutorial/version.Version=$(VERSION) \
+	-X github.com/cosmos/sdk-application-tutorial/version.Commit=$(COMMIT)
 
 get_tools:
 ifndef DEP
@@ -19,5 +26,5 @@ update_vendor_deps:
 	@dep ensure -v -update
 
 install:
-	go install ./cmd/nsd
-	go install ./cmd/nscli
+	go install -ldflags '$(ldflags)' ./cmd/nsd
+	go install -ldflags '$(ldflags)' ./cmd/nscli

--- a/cmd/nscli/main.go
+++ b/cmd/nscli/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/lcd"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	amino "github.com/tendermint/go-amino"
@@ -21,6 +20,7 @@ import (
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/client/rest"
 	app "github.com/cosmos/sdk-application-tutorial"
+	"github.com/cosmos/sdk-application-tutorial/version"
 	nsclient "github.com/cosmos/sdk-application-tutorial/x/nameservice/client"
 	nsrest "github.com/cosmos/sdk-application-tutorial/x/nameservice/client/rest"
 )

--- a/cmd/nsd/main.go
+++ b/cmd/nsd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/sdk-application-tutorial/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/crypto"
@@ -51,7 +52,7 @@ func main() {
 
 	rootCmd.AddCommand(InitCmd(ctx, cdc))
 	rootCmd.AddCommand(AddGenesisAccountCmd(ctx, cdc))
-
+	rootCmd.AddCommand(version.VersionCmd)
 	server.AddCommands(ctx, cdc, rootCmd, newApp, appExporter())
 
 	// prepare and add flags

--- a/version/command.go
+++ b/version/command.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/cli"
+)
+
+const flagLong = "long"
+
+func init() {
+	VersionCmd.Flags().Bool(flagLong, false, "Print long version information")
+}
+
+// VersionCmd prints out the built namespace application version.
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the app version",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		verInfo := newVersionInfo()
+
+		if !viper.GetBool(flagLong) {
+			fmt.Println(verInfo.NameService)
+			return nil
+		}
+
+		if viper.GetString(cli.OutputFlag) != "json" {
+			fmt.Print(verInfo)
+			return nil
+		}
+
+		bz, err := json.Marshal(verInfo)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(bz))
+		return nil
+	},
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,34 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Version/build values set at build time
+var (
+	Commit  = ""
+	Version = ""
+)
+
+type versionInfo struct {
+	NameService string `json:"nameservice"`
+	GitCommit   string `json:"commit"`
+	GoVersion   string `json:"go"`
+}
+
+func newVersionInfo() versionInfo {
+	return versionInfo{
+		Version,
+		Commit,
+		fmt.Sprintf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+func (v versionInfo) String() string {
+	return fmt.Sprintf(`nameservice: %s
+git commit: %s
+%s`, 
+v.NameService, v.GitCommit,  v.GoVersion,
+)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -28,7 +28,7 @@ func newVersionInfo() versionInfo {
 func (v versionInfo) String() string {
 	return fmt.Sprintf(`nameservice: %s
 git commit: %s
-%s`, 
-v.NameService, v.GitCommit,  v.GoVersion,
-)
+%s`,
+		v.NameService, v.GitCommit, v.GoVersion,
+	)
 }


### PR DESCRIPTION
Implements a basic version command. Note, we should start using tags for this tutorial/app. But for now, it's hard-coded to 0.0.1.

Now you can run `nsd/nscli version --long`