### PR TITLE
an arguably better wording about the "store key"

### DIFF
--- a/tutorial/en/keeper.md
+++ b/tutorial/en/keeper.md
@@ -35,9 +35,7 @@ A couple of notes about the above code:
 * The `Keeper` struct. In this keeper there are a couple of key pieces:
 	- [`bank.Keeper`](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank#Keeper) - This is a reference to the `Keeper` from the `bank` module. Including it allows code in this module to call functions from the `bank` module. The SDK uses an [object capabilities](https://en.wikipedia.org/wiki/Object-capability_model) approach to accessing sections of the application state. This is to allow developers to employ a least authority approach, limiting the capabilities of a faulty or malicious module from affecting parts of state it doesn't need access to.
 	- [`*codec.Codec`](https://godoc.org/github.com/cosmos/cosmos-sdk/codec#Codec) - This is a pointer to the codec that is used by Amino to encode and decode binary structs.
-	- [`sdk.StoreKey`](https://godoc.org/github.com/cosmos/cosmos-sdk/types#StoreKey) -  This gates access to a `sdk.KVStore` that persists the state of your application.
-* This module has 1 store keys:
-	- `storeKey` - This is the main store that stores the Whois struct that the name points to (i.e. `map[name]Whois`).
+	- [`sdk.StoreKey`](https://godoc.org/github.com/cosmos/cosmos-sdk/types#StoreKey) -  This is a store key which gates access to a `sdk.KVStore` which persists the state of your application: the Whois struct that the name points to (i.e. `map[name]Whois`).
 
 ## Getters and Setters
 


### PR DESCRIPTION
I wanted to fix the misprint first (`This module has 1 store keys `), but ended up merging the two paragraphs. IMHO it looks a bit more concise and clear.