### PR TITLE
Fix queries in the tutorial

### DIFF
--- a/x/nameservice/alias.go
+++ b/x/nameservice/alias.go
@@ -14,6 +14,8 @@ var (
 	NewMsgBuyName = types.NewMsgBuyName
 	NewMsgSetName = types.NewMsgSetName
 	NewWhois      = types.NewWhois
+	ModuleCdc     = types.ModuleCdc
+	RegisterCodec = types.RegisterCodec
 )
 
 type (

--- a/x/nameservice/querier.go
+++ b/x/nameservice/querier.go
@@ -31,51 +31,46 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 // nolint: unparam
-func queryResolve(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
-	name := path[0]
-
-	value := keeper.ResolveName(ctx, name)
+func queryResolve(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	value := keeper.ResolveName(ctx, path[0])
 
 	if value == "" {
 		return []byte{}, sdk.ErrUnknownRequest("could not resolve name")
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, QueryResResolve{value})
-	if err2 != nil {
+	res, err := codec.MarshalJSONIndent(keeper.cdc, QueryResResolve{value})
+	if err != nil {
 		panic("could not marshal result to JSON")
 	}
 
-	return bz, nil
+	return res, nil
 }
 
 // nolint: unparam
-func queryWhois(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
-	name := path[0]
+func queryWhois(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	whois := keeper.GetWhois(ctx, path[0])
 
-	whois := keeper.GetWhois(ctx, name)
-
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, whois)
-	if err2 != nil {
+	res, err := codec.MarshalJSONIndent(keeper.cdc, whois)
+	if err != nil {
 		panic("could not marshal result to JSON")
 	}
 
-	return bz, nil
+	return res, nil
 }
 
-func queryNames(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) (res []byte, err sdk.Error) {
+func queryNames(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var namesList QueryResNames
 
 	iterator := keeper.GetNamesIterator(ctx)
 
 	for ; iterator.Valid(); iterator.Next() {
-		name := string(iterator.Key())
-		namesList = append(namesList, name)
+		namesList = append(namesList, string(iterator.Key()))
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, namesList)
-	if err2 != nil {
+	res, err := codec.MarshalJSONIndent(keeper.cdc, namesList)
+	if err != nil {
 		panic("could not marshal result to JSON")
 	}
 
-	return bz, nil
+	return res, nil
 }

--- a/x/nameservice/types/codec.go
+++ b/x/nameservice/types/codec.go
@@ -1,13 +1,17 @@
-package nameservice
+package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
+
+var ModuleCdc = codec.New()
+
+func init() {
+	RegisterCodec(ModuleCdc)
+}
 
 // RegisterCodec registers concrete types on the Amino codec
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgSetName{}, "nameservice/SetName", nil)
 	cdc.RegisterConcrete(MsgBuyName{}, "nameservice/BuyName", nil)
 }
-
-var ModuleCdc = codec.New()

--- a/x/nameservice/types/key.go
+++ b/x/nameservice/types/key.go
@@ -5,5 +5,5 @@ const (
 	ModuleName = "nameservice"
 
 	// StoreKey to be used when creating the KVStore
-	StoreKey = "ns"
+	StoreKey = ModuleName
 )

--- a/x/nameservice/types/msgs.go
+++ b/x/nameservice/types/msgs.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"encoding/json"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -10,9 +8,9 @@ const RouterKey = ModuleName // this was defined in your key.go file
 
 // MsgSetName defines a SetName message
 type MsgSetName struct {
-	Name  string
-	Value string
-	Owner sdk.AccAddress
+	Name  string         `json:"name"`
+	Value string         `json:"value"`
+	Owner sdk.AccAddress `json:"owner"`
 }
 
 // NewMsgSetName is a constructor function for MsgSetName
@@ -43,11 +41,7 @@ func (msg MsgSetName) ValidateBasic() sdk.Error {
 
 // GetSignBytes encodes the message for signing
 func (msg MsgSetName) GetSignBytes() []byte {
-	b, err := json.Marshal(msg)
-	if err != nil {
-		panic(err)
-	}
-	return sdk.MustSortJSON(b)
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
 }
 
 // GetSigners defines whose signature is required
@@ -57,9 +51,9 @@ func (msg MsgSetName) GetSigners() []sdk.AccAddress {
 
 // MsgBuyName defines the BuyName message
 type MsgBuyName struct {
-	Name  string
-	Bid   sdk.Coins
-	Buyer sdk.AccAddress
+	Name  string         `json:"name"`
+	Bid   sdk.Coins      `json:"bid"`
+	Buyer sdk.AccAddress `json:"buyer"`
 }
 
 // NewMsgBuyName is the constructor function for MsgBuyName
@@ -93,11 +87,7 @@ func (msg MsgBuyName) ValidateBasic() sdk.Error {
 
 // GetSignBytes encodes the message for signing
 func (msg MsgBuyName) GetSignBytes() []byte {
-	b, err := json.Marshal(msg)
-	if err != nil {
-		panic(err)
-	}
-	return sdk.MustSortJSON(b)
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
 }
 
 // GetSigners defines whose signature is required


### PR DESCRIPTION
The ModuleName and the StoreKey were not set to the same string causing query routing issues. This has been changed and the `q nameservice` commands are now returning as expected.  