### PR TITLE
Fix broken link in Cosmos sdk tutorial

### DIFF
--- a/tutorial/msgs-handlers.md
+++ b/tutorial/msgs-handlers.md
@@ -4,7 +4,7 @@ Now that you have the `Keeper` setup, it is time to build the `Msgs` and `Handle
 
 ## `Msgs`
 
-`Msgs` trigger state transitions. `Msgs` are wrapped in [`Txs`](https://github.com/cosmos/cosmos-sdk/blob/develop/types/tx_msg.go#L34-L38) that clients submit to the network. The Cosmos SDK wraps and unwraps `Msgs` from `Txs`, which means, as an app developer, you only have to define `Msgs`. `Msgs` must satisfy the following interface (we'll implement all of these in the next section):
+`Msgs` trigger state transitions. `Msgs` are wrapped in [`Txs`](https://github.com/cosmos/cosmos-sdk/blob/master/types/tx_msg.go#L34-L38) that clients submit to the network. The Cosmos SDK wraps and unwraps `Msgs` from `Txs`, which means, as an app developer, you only have to define `Msgs`. `Msgs` must satisfy the following interface (we'll implement all of these in the next section):
 
 ```go
 // Transactions messages must fulfill the Msg


### PR DESCRIPTION
Looks like the develop branch isn't there anymore. Might be better to have the link point to master instead!