### PR TITLE
app.go - re-add nameservice storeKey. Fixes #135

### DIFF
--- a/app.go
+++ b/app.go
@@ -102,7 +102,8 @@ func NewNameServiceApp(
 	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), baseAppOptions...)
 
 	keys := sdk.NewKVStoreKeys(bam.MainStoreKey, auth.StoreKey, staking.StoreKey,
-		supply.StoreKey, distr.StoreKey, slashing.StoreKey, params.StoreKey)
+		supply.StoreKey, distr.StoreKey, slashing.StoreKey, params.StoreKey, nameservice.StoreKey)
+
 	tkeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
 
 	// Here you initialize your application with the store keys it requires


### PR DESCRIPTION
oopsie! Looks like we forgot the nameservice store key in the last update. Easy fix.