### PR TITLE
[update]app.go-init-genesis

### DIFF
--- a/app.go
+++ b/app.go
@@ -222,6 +222,7 @@ func NewNameServiceApp(
 		bank.ModuleName,
 		slashing.ModuleName,
 		nameservice.ModuleName,
+		supply.ModuleName,
 		genutil.ModuleName,
 	)
 


### PR DESCRIPTION
SupplyModule was missing in SetOrderInitGenesis